### PR TITLE
Add purescript-0.13.0

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,6 +23,7 @@ in
   purescript_0_12_3 = callPackage ./purescript/purescript_0_12_3 {};
   purescript_0_12_4 = callPackage ./purescript/purescript_0_12_4 {};
   purescript_0_12_5 = callPackage ./purescript/purescript_0_12_5 {};
+  purescript_0_13_0 = callPackage ./purescript/purescript_0_13_0 {};
 
   spago_0_7_2_0 = callPackage ./purescript/spago_0_7_2_0 {};
 

--- a/pkgs/purescript/mkPurescriptPkg.nix
+++ b/pkgs/purescript/mkPurescriptPkg.nix
@@ -1,4 +1,4 @@
-{ version, sha256 }:
+{ version, sha256, extraDepends? [] }:
 { mkDerivation, aeson, aeson-better-errors, ansi-terminal
 , ansi-wl-pprint, base, base-compat, blaze-html, bower-json, boxes
 , bytestring, Cabal, cheapskate, clock, containers, data-ordlist
@@ -29,7 +29,7 @@ mkDerivation {
     semigroups sourcemap split stm stringsearch syb text time
     transformers transformers-base transformers-compat
     unordered-containers utf8-string vector
-  ];
+  ] ++ extraDepends;
   executableHaskellDepends = [
     aeson aeson-better-errors ansi-terminal ansi-wl-pprint base
     base-compat blaze-html bower-json boxes bytestring Cabal cheapskate
@@ -42,7 +42,7 @@ mkDerivation {
     transformers transformers-base transformers-compat
     unordered-containers utf8-string vector wai wai-websockets warp
     websockets
-  ];
+  ] ++ extraDepends;
   testHaskellDepends = [
     aeson aeson-better-errors ansi-terminal base base-compat blaze-html
     bower-json boxes bytestring Cabal cheapskate clock containers
@@ -54,7 +54,7 @@ mkDerivation {
     stringsearch syb tasty tasty-hspec text time transformers
     transformers-base transformers-compat unordered-containers
     utf8-string vector
-  ];
+  ] ++ extraDepends;
   testToolDepends = [ hspec-discover ];
   doCheck = false;
   homepage = "http://www.purescript.org/";

--- a/pkgs/purescript/purescript_0_13_0/default.nix
+++ b/pkgs/purescript/purescript_0_13_0/default.nix
@@ -1,0 +1,32 @@
+{ haskell }:
+
+let
+  ghc = haskell.packages.ghc864;
+  networkPkg =
+    { mkDerivation, base, bytestring, deepseq, directory, hspec
+    , hspec-discover, HUnit, stdenv
+    }:
+    mkDerivation {
+      pname = "network";
+      version = "3.0.1.1";
+      sha256 = "d2bc064ea56c14275ff755800c3dd033ad6092fb24ad1783f9ec10c70bdd4cf5";
+      libraryHaskellDepends = [ base bytestring deepseq ];
+      testHaskellDepends = [ base bytestring directory hspec HUnit ];
+      testToolDepends = [ hspec-discover ];
+      homepage = "https://github.com/haskell/network";
+      description = "Low-level networking interface";
+      license = stdenv.lib.licenses.bsd3;
+    };
+  purescriptPkg = import ../mkPurescriptPkg.nix {
+    version = "0.13.0";
+    sha256 = "1cpdbb48a8qs57adc37qkcfaszj3m6gds6gdq07iq11b6gmfzr3q";
+    extraDepends = [ packages.happy ];
+  };
+  packages = ghc.override {
+    overrides = haskellPackagesNew: haskellPackagesOld: rec {
+      network = haskellPackagesNew.callPackage networkPkg {};
+      purescript = haskellPackagesNew.callPackage purescriptPkg {};
+    };
+  };
+in
+  packages.purescript


### PR DESCRIPTION
I've added `extraDepends` - single argument to `mkPurescriptPkg`. Currently we don't have to split extra dependencies like `executableHaskellExtraDepends`, `libraryHaskellExtraDepends` and `testHaskellExtraDepends` because `happy` is a new dependency for all of them. Of course I can split these dependencies (by turning `extraDepends` into record) for clarity if you want me to. Should I?