### PR TITLE
Use master branch of install-nix-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install nix
-        uses: cachix/install-nix-action@v10
+        uses: cachix/install-nix-action@master
         with:
           nix_path: nixpkgs=channel:nixos-20.03
 


### PR DESCRIPTION
Use master branch to include https://github.com/cachix/install-nix-action/pull/37 for more stable builds